### PR TITLE
Add useHover hook with customizable hover tracking

### DIFF
--- a/packages/common-fe/src/hooks/index.ts
+++ b/packages/common-fe/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './use-debounce';
+export * from './use-hover';
 export * from './use-isomorphic-layout-effect';
 export * from './use-latest';
 export * from './use-throttle';

--- a/packages/common-fe/src/hooks/use-hover/README.md
+++ b/packages/common-fe/src/hooks/use-hover/README.md
@@ -1,0 +1,429 @@
+# useHover Hook
+
+A React hook that tracks the hover state of an element with advanced customization options including delays, pointer type filtering, and keyboard accessibility support.
+
+## Features
+
+- 🎯 Tracks hover state with ref-based element targeting
+- ⏱️ Configurable enter/leave delays for better UX
+- 🖱️ Pointer type filtering (mouse, pen, touch)
+- ⌨️ Optional keyboard accessibility (focus/blur)
+- 🔄 Automatic cleanup on unmount
+- 📝 Full TypeScript support
+- ♿ Accessibility-friendly with `includeFocus` option
+
+## Usage
+
+### Basic Usage
+
+```tsx
+import React, { useRef } from 'react';
+import { useHover } from '@ur-apps/common-fe';
+
+function BasicHoverComponent() {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const isHovered = useHover(buttonRef);
+
+  return (
+    <button
+      ref={buttonRef}
+      style={{
+        backgroundColor: isHovered ? 'lightblue' : 'white',
+        padding: '10px 20px',
+        border: '1px solid #ccc',
+      }}>
+      {isHovered ? 'Hovering!' : 'Hover over me'}
+    </button>
+  );
+}
+```
+
+### With Delays
+
+```tsx
+import React, { useRef } from 'react';
+import { useHover } from '@ur-apps/common-fe';
+
+function TooltipComponent() {
+  const elementRef = useRef<HTMLDivElement>(null);
+  const isHovered = useHover(elementRef, {
+    enterDelay: 500, // Wait 500ms before showing tooltip
+    leaveDelay: 200, // Wait 200ms before hiding tooltip
+  });
+
+  return (
+    <div ref={elementRef} style={{ position: 'relative', display: 'inline-block' }}>
+      <span>Hover over me</span>
+      {isHovered && (
+        <div
+          style={{
+            position: 'absolute',
+            bottom: '100%',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            padding: '8px',
+            backgroundColor: 'black',
+            color: 'white',
+            borderRadius: '4px',
+            whiteSpace: 'nowrap',
+          }}>
+          This is a tooltip!
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+### With onChange Callback
+
+```tsx
+import React, { useRef, useState } from 'react';
+import { useHover } from '@ur-apps/common-fe';
+
+function ImagePreviewComponent() {
+  const imageRef = useRef<HTMLImageElement>(null);
+  const [hoverCount, setHoverCount] = useState(0);
+
+  const isHovered = useHover(imageRef, {
+    onChange: (hovered) => {
+      console.log('Hover state changed:', hovered);
+      if (hovered) {
+        setHoverCount((prev) => prev + 1);
+      }
+    },
+  });
+
+  return (
+    <div>
+      <img
+        ref={imageRef}
+        src="/path/to/image.jpg"
+        alt="Hover me"
+        style={{
+          border: isHovered ? '3px solid blue' : '1px solid gray',
+          transition: 'border 0.2s',
+        }}
+      />
+      <p>Hover count: {hoverCount}</p>
+    </div>
+  );
+}
+```
+
+### With Keyboard Accessibility
+
+```tsx
+import React, { useRef } from 'react';
+import { useHover } from '@ur-apps/common-fe';
+
+function AccessibleCardComponent() {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const isHovered = useHover(cardRef, {
+    includeFocus: true, // Also activate on keyboard focus
+  });
+
+  return (
+    <div
+      ref={cardRef}
+      tabIndex={0} // Make focusable for keyboard navigation
+      style={{
+        padding: '20px',
+        border: '2px solid',
+        borderColor: isHovered ? 'blue' : 'gray',
+        backgroundColor: isHovered ? '#f0f8ff' : 'white',
+        cursor: 'pointer',
+        outline: 'none',
+      }}>
+      <h3>Accessible Card</h3>
+      <p>Hover with mouse or focus with keyboard (Tab key)</p>
+      {isHovered && <p>✓ Currently active</p>}
+    </div>
+  );
+}
+```
+
+### Pointer Type Filtering
+
+```tsx
+import React, { useRef } from 'react';
+import { useHover } from '@ur-apps/common-fe';
+
+function TouchExcludedComponent() {
+  const elementRef = useRef<HTMLDivElement>(null);
+
+  // Only respond to mouse and pen, not touch
+  const isHovered = useHover(elementRef, {
+    pointerTypes: ['mouse', 'pen'], // Default: excludes touch
+  });
+
+  return (
+    <div
+      ref={elementRef}
+      style={{
+        padding: '20px',
+        backgroundColor: isHovered ? 'lightgreen' : 'lightgray',
+      }}>
+      This only responds to mouse/pen hover, not touch
+    </div>
+  );
+}
+
+function TouchIncludedComponent() {
+  const elementRef = useRef<HTMLDivElement>(null);
+
+  // Respond to all pointer types including touch
+  const isHovered = useHover(elementRef, {
+    pointerTypes: ['mouse', 'pen', 'touch'],
+  });
+
+  return (
+    <div
+      ref={elementRef}
+      style={{
+        padding: '20px',
+        backgroundColor: isHovered ? 'lightcoral' : 'lightgray',
+      }}>
+      This responds to mouse, pen, AND touch
+    </div>
+  );
+}
+```
+
+### Conditional Disabling
+
+```tsx
+import React, { useRef, useState } from 'react';
+import { useHover } from '@ur-apps/common-fe';
+
+function ConditionalHoverComponent() {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [isDisabled, setIsDisabled] = useState(false);
+
+  const isHovered = useHover(buttonRef, {
+    disabled: isDisabled, // Disable hover tracking when button is disabled
+  });
+
+  return (
+    <div>
+      <button
+        ref={buttonRef}
+        disabled={isDisabled}
+        style={{
+          padding: '10px 20px',
+          backgroundColor: isHovered ? 'lightblue' : 'white',
+          opacity: isDisabled ? 0.5 : 1,
+          cursor: isDisabled ? 'not-allowed' : 'pointer',
+        }}>
+        {isHovered ? 'Hovering!' : 'Button'}
+      </button>
+      <br />
+      <label>
+        <input type="checkbox" checked={isDisabled} onChange={(e) => setIsDisabled(e.target.checked)} />
+        Disable button
+      </label>
+    </div>
+  );
+}
+```
+
+### Advanced: Dropdown Menu
+
+```tsx
+import React, { useRef, useState } from 'react';
+import { useHover } from '@ur-apps/common-fe';
+
+function DropdownMenu() {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const isTriggerHovered = useHover(triggerRef, {
+    enterDelay: 200,
+    leaveDelay: 300,
+  });
+
+  const isMenuHovered = useHover(menuRef, {
+    leaveDelay: 300,
+  });
+
+  const showMenu = isTriggerHovered || isMenuHovered;
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <button
+        ref={triggerRef}
+        style={{
+          padding: '10px 20px',
+          backgroundColor: showMenu ? '#007bff' : '#0056b3',
+          color: 'white',
+          border: 'none',
+          borderRadius: '4px',
+        }}>
+        Menu ▼
+      </button>
+
+      {showMenu && (
+        <div
+          ref={menuRef}
+          style={{
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            marginTop: '4px',
+            backgroundColor: 'white',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+            minWidth: '200px',
+            zIndex: 1000,
+          }}>
+          <div style={{ padding: '8px 12px', cursor: 'pointer' }}>Item 1</div>
+          <div style={{ padding: '8px 12px', cursor: 'pointer' }}>Item 2</div>
+          <div style={{ padding: '8px 12px', cursor: 'pointer' }}>Item 3</div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+## API
+
+### Parameters
+
+```typescript
+useHover<T extends HTMLElement = HTMLElement>(
+  targetRef: RefObject<T | null>,
+  options?: UseHoverOptions
+): boolean
+```
+
+- `targetRef: RefObject<T | null>` - React ref to the target element to track
+- `options?: UseHoverOptions` - Optional configuration object
+
+### Options
+
+```typescript
+type UseHoverOptions = {
+  enterDelay?: number; // Default: 0
+  leaveDelay?: number; // Default: 0
+  disabled?: boolean; // Default: false
+  includeFocus?: boolean; // Default: false
+  pointerTypes?: PointerType[]; // Default: ['mouse', 'pen']
+  onChange?: (hovered: boolean) => void;
+};
+
+type PointerType = 'mouse' | 'pen' | 'touch';
+```
+
+#### Option Details
+
+- **`enterDelay`** - Delay in milliseconds before setting hovered to `true`. Useful for tooltips that shouldn't appear instantly.
+- **`leaveDelay`** - Delay in milliseconds before setting hovered to `false`. Prevents flickering when mouse briefly leaves element.
+
+- **`disabled`** - When `true`, disables hover tracking, removes event listeners, and sets hovered to `false`.
+
+- **`includeFocus`** - When `true`, also tracks focus/blur events for keyboard accessibility. Essential for accessible interactive elements.
+
+- **`pointerTypes`** - Array of pointer types to respond to:
+  - `['mouse', 'pen']` (default) - Desktop/stylus only
+  - `['mouse', 'pen', 'touch']` - Include touch devices
+  - `['mouse']` - Mouse only
+
+- **`onChange`** - Callback function called whenever hover state changes. Receives the new hover state as argument.
+
+### Returns
+
+`boolean` - Current hover state (`true` when hovered, `false` otherwise)
+
+## Use Cases
+
+### When to use `useHover`
+
+- **Tooltips** - Show additional information on hover
+- **Preview cards** - Display expanded content on hover
+- **Image galleries** - Show controls or overlays on hover
+- **Navigation menus** - Dropdown or mega menus
+- **Interactive buttons** - Visual feedback for user interactions
+- **Data visualizations** - Highlight chart elements on hover
+- **Card animations** - Scale, lift, or transform on hover
+
+### Common Patterns
+
+#### 1. Delayed Tooltips
+
+```tsx
+const isHovered = useHover(ref, {
+  enterDelay: 700, // Don't show immediately
+  leaveDelay: 100, // Hide quickly
+});
+```
+
+#### 2. Sticky Hover (for complex interactions)
+
+```tsx
+const isHovered = useHover(ref, {
+  enterDelay: 0, // Show immediately
+  leaveDelay: 500, // Keep visible longer
+});
+```
+
+#### 3. Keyboard Accessible Elements
+
+```tsx
+const isActive = useHover(ref, {
+  includeFocus: true, // Activate on Tab key focus
+});
+```
+
+#### 4. Touch-Friendly (Mobile)
+
+```tsx
+const isHovered = useHover(ref, {
+  pointerTypes: ['mouse', 'pen', 'touch'], // Include touch
+});
+```
+
+#### 5. Analytics Tracking
+
+```tsx
+const isHovered = useHover(ref, {
+  onChange: (hovered) => {
+    if (hovered) {
+      trackEvent('element_hovered');
+    }
+  },
+});
+```
+
+## Implementation Details
+
+The hook internally:
+
+- Uses `useLatest` to ensure options always use the most recent values without recreating event handlers
+- Automatically detects `PointerEvent` support and falls back to `MouseEvent`
+- Manages enter/leave timers with automatic cleanup
+- Clears all timers when element becomes disabled or unmounted
+- Filters events based on `pointerType` when using `PointerEvent` API
+
+## Performance Considerations
+
+- Event listeners are only attached when element exists and is not disabled
+- Timers are properly cleaned up to prevent memory leaks
+- Options changes don't recreate event handlers (thanks to `useLatest`)
+- The hook automatically handles element changes via ref updates
+
+## Accessibility Notes
+
+- Use `includeFocus: true` for interactive elements to support keyboard navigation
+- Ensure focused elements have visible focus indicators (outline)
+- Add `tabIndex={0}` to make non-interactive elements keyboard-focusable
+- Consider ARIA attributes (`aria-haspopup`, `aria-expanded`) for dropdowns
+- Avoid relying solely on hover for critical functionality (think mobile/touch users)
+
+## Browser Compatibility
+
+- **Modern browsers**: Full support with `PointerEvent` API
+- **Legacy browsers**: Automatic fallback to `MouseEvent` API
+- **Touch devices**: Configurable via `pointerTypes` option
+- **Keyboard navigation**: Supported via `includeFocus` option

--- a/packages/common-fe/src/hooks/use-hover/constants.ts
+++ b/packages/common-fe/src/hooks/use-hover/constants.ts
@@ -1,0 +1,8 @@
+import { PointerType } from './types';
+
+export const SUPPORTS_POINTER = typeof PointerEvent !== 'undefined';
+export const ENTER_EVENT = SUPPORTS_POINTER ? 'pointerenter' : 'mouseenter';
+export const LEAVE_EVENT = SUPPORTS_POINTER ? 'pointerleave' : 'mouseleave';
+export const FOCUS_EVENT = 'focus';
+export const BLUR_EVENT = 'blur';
+export const DEFAULT_POINTER_TYPES: PointerType[] = ['mouse', 'pen'];

--- a/packages/common-fe/src/hooks/use-hover/index.ts
+++ b/packages/common-fe/src/hooks/use-hover/index.ts
@@ -1,0 +1,2 @@
+export * from './use-hover';
+export * from './types';

--- a/packages/common-fe/src/hooks/use-hover/types.ts
+++ b/packages/common-fe/src/hooks/use-hover/types.ts
@@ -1,0 +1,33 @@
+export type PointerType = 'mouse' | 'pen' | 'touch';
+
+export type UseHoverOptions = {
+  /**
+   * Delay before setting hovered to true (ms)
+   * @default 0
+   */
+  enterDelay?: number;
+  /**
+   * Delay before setting hovered to false (ms)
+   * @default 0
+   */
+  leaveDelay?: number;
+  /**
+   * Disable the hook (removes hover and handlers)
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * Also trigger on focus/blur (for keyboard accessibility)
+   * @default false
+   */
+  includeFocus?: boolean;
+  /**
+   * Limit pointer types considered as hover
+   * @default ['mouse', 'pen']
+   */
+  pointerTypes?: PointerType[];
+  /**
+   * Callback on state change
+   */
+  onChange?: (hovered: boolean) => void;
+};

--- a/packages/common-fe/src/hooks/use-hover/use-hover.ts
+++ b/packages/common-fe/src/hooks/use-hover/use-hover.ts
@@ -1,0 +1,139 @@
+import { RefObject, useEffect, useRef, useState } from 'react';
+
+import { useLatest } from '../use-latest';
+
+import { BLUR_EVENT, DEFAULT_POINTER_TYPES, ENTER_EVENT, FOCUS_EVENT, LEAVE_EVENT } from './constants';
+import { PointerType, UseHoverOptions } from './types';
+
+export function useHover<T extends HTMLElement = HTMLElement>(
+  targetRef: RefObject<T | null>,
+  options: UseHoverOptions = {}
+): boolean {
+  const {
+    enterDelay = 0,
+    leaveDelay = 0,
+    disabled = false,
+    includeFocus = false,
+    pointerTypes = DEFAULT_POINTER_TYPES,
+    onChange,
+  } = options;
+  const optionsRef = useLatest({ enterDelay, leaveDelay, pointerTypes, onChange });
+
+  const [hovered, setHovered] = useState(false);
+
+  const enterTimer = useRef<number | null>(null);
+  const leaveTimer = useRef<number | null>(null);
+
+  const clearTimer = (timerRef: RefObject<number | null>) => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    const element = targetRef.current;
+
+    if (!element || disabled) {
+      clearTimer(enterTimer);
+      clearTimer(leaveTimer);
+
+      setHovered(false);
+
+      return;
+    }
+
+    const matchesPointer = (evt: PointerEvent | MouseEvent) => {
+      const { pointerTypes } = optionsRef.current;
+
+      if (pointerTypes.length && evt instanceof PointerEvent) {
+        return pointerTypes.includes(evt.pointerType as PointerType);
+      }
+
+      return true;
+    };
+
+    const handleEnter = (evt: PointerEvent | MouseEvent) => {
+      if (!matchesPointer(evt)) return;
+
+      const { enterDelay, onChange } = optionsRef.current;
+
+      clearTimer(enterTimer);
+      clearTimer(leaveTimer);
+
+      if (enterDelay > 0) {
+        enterTimer.current = setTimeout(() => {
+          setHovered(true);
+          onChange?.(true);
+        }, enterDelay);
+      } else {
+        setHovered(true);
+        onChange?.(true);
+      }
+    };
+
+    const handleLeave = (evt: PointerEvent | MouseEvent) => {
+      if (!matchesPointer(evt)) return;
+
+      const { leaveDelay, onChange } = optionsRef.current;
+
+      clearTimer(enterTimer);
+      clearTimer(leaveTimer);
+
+      if (leaveDelay > 0) {
+        leaveTimer.current = setTimeout(() => {
+          setHovered(false);
+          onChange?.(false);
+        }, leaveDelay);
+      } else {
+        setHovered(false);
+        onChange?.(false);
+      }
+    };
+
+    const handleFocus = () => {
+      const { onChange } = optionsRef.current;
+
+      clearTimer(enterTimer);
+      clearTimer(leaveTimer);
+
+      setHovered(true);
+      onChange?.(true);
+    };
+
+    const handleBlur = () => {
+      const { onChange } = optionsRef.current;
+
+      clearTimer(enterTimer);
+      clearTimer(leaveTimer);
+
+      setHovered(false);
+      onChange?.(false);
+    };
+
+    element.addEventListener(ENTER_EVENT, handleEnter);
+    element.addEventListener(LEAVE_EVENT, handleLeave);
+
+    if (includeFocus) {
+      element.addEventListener(FOCUS_EVENT, handleFocus);
+      element.addEventListener(BLUR_EVENT, handleBlur);
+    }
+
+    return () => {
+      clearTimer(enterTimer);
+      clearTimer(leaveTimer);
+
+      element.removeEventListener(ENTER_EVENT, handleEnter);
+      element.removeEventListener(LEAVE_EVENT, handleLeave);
+
+      if (includeFocus) {
+        element.removeEventListener(FOCUS_EVENT, handleFocus);
+        element.removeEventListener(BLUR_EVENT, handleBlur);
+      }
+    };
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetRef.current, optionsRef, disabled, includeFocus]);
+
+  return hovered;
+}


### PR DESCRIPTION
### 🤔 What kind of change does this PR introduce?
- [x] Feature
- [ ] Bugfix
- [ ] Refactors
- [x] Optimization
- [x] Documentation
- [ ] Other

### 📝 Description
This pull request introduces a new reusable `useHover` React hook to the `common-fe` package, which provides a robust and configurable way to detect hover and focus states on DOM elements. The hook supports pointer type filtering, enter/leave delays, keyboard accessibility, and an `onChange` callback. Several supporting files and exports were added to integrate this hook into the codebase.

### 🔗 Related issue link
- closes NO TASK

### 📋 Changelog
**New hook implementation and integration:**

* Added the `useHover` hook in `use-hover.ts`, which tracks hover state with support for enter/leave delays, pointer type filtering, keyboard accessibility (focus/blur), and an `onChange` callback.
* Defined the `UseHoverOptions` type and `PointerType` union in `types.ts` to configure the hook's behavior.
* Created constants in `constants.ts` for event names and default pointer types, supporting both pointer and mouse events.

### ✅ Checklist
- Tested on
  - [x] **Chrome**
  - [ ] **Firefox**
  - [x] **Safari**
  - [ ] **Mobile**
- [ ] Added appropriate **tests**
- [x] Added necessary comments
- [x] Removed dead code
- [x] Performed a self-review of my own code
